### PR TITLE
sphinxcontrib-applehelp 1.0.4

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "1.0.2" %}
+{% set version = "1.0.4" %}
 
 package:
   name: sphinxcontrib-applehelp
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/s/sphinxcontrib-applehelp/sphinxcontrib-applehelp-{{ version }}.tar.gz
-  sha256: a072735ec80e7675e3f432fcae8610ecf509c5f1869d17e2eecff44389cdbc58
+  sha256: 828f867945bbe39817c210a1abfd1bc4895c8b73fcaade56d45357a348a07d7e
 
 build:
   number: 0


### PR DESCRIPTION
**Recipe directory diff between current master and this update:**
``` diff
diff --git a/recipe/meta.yaml b/recipe/meta.yaml
index 4561a70..99be7fd 100644
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "1.0.2" %}
+{% set version = "1.0.4" %}
 
 package:
   name: sphinxcontrib-applehelp
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/s/sphinxcontrib-applehelp/sphinxcontrib-applehelp-{{ version }}.tar.gz
-  sha256: a072735ec80e7675e3f432fcae8610ecf509c5f1869d17e2eecff44389cdbc58
+  sha256: 828f867945bbe39817c210a1abfd1bc4895c8b73fcaade56d45357a348a07d7e
 
 build:
   number: 0

```

**Jira ticket:** []() (-)

**The upstream data:**

**_Actions:_**

1. 

**_Notes:_**
 * 

**Additional info:**

<details>

**Package's statistics**

<details>

 * Priority C | effort: easy | Category: anaconda | subcategory: dependency | pkg_type: python
 * Outdated platfroms: 'linux-64', 'linux-aarch64', 'linux-s390x', 'linux-ppc64le', 'osx-64', 'osx-arm64', 'win-64'
 * Latest version: 1.0.4
 * Release on PyPi:
    * version: 1.0.4
    * date: 2023-01-23T09:41:54
* [PyPi history](https://pypi.org/project/sphinxcontrib-applehelp/#history)
 * Popularity: 
    * 3 months downloads: 253080.0
    * All time:  4729674 downloads -  sphinxcontrib-applehelp  1.0.4  sphinxcontrib-applehelp is a sphinx extension which outputs Apple help books  

</details>

**Other checks:**

<details>

1. - [ ] Check the pinnings
2. - [ ] Verify that the `build_number` is correct
4. - [ ] Verify if the package needs `setuptools`
    
6. - [ ] Verify if the package needs `wheel`
    
7. - [x] `pip` in test
9. - [ ] Verify the test section
10. - [ ] Verify if the package is `architecture specific`
11. - [ ] Verify that private modules are not mentioned in the recipe For example: (_private_module)
12.  - [x] license_file: LICENSE is present

14. - [x] license_family BSD is present
16. - [x] License: BSD-2-Clause
    - [x] License is `spdx` compliant
 * Check if the license identifier has correct name from the SPDX License List

| Identifier          |
|:--------------------|
| BSD-2-Clause        |
| BSD-2-Clause-Patent |
| BSD-2-Clause-Views  |
</details>

**Check dependency issues:**

<details>
../aggregate/sphinxcontrib-applehelp-feedstock/recipe/meta.yaml
Dependencies: ['pip', 'python >=3.5']


noarch:
- py3.7:  No issues found
- py3.8:  No issues found
- py3.9:  No issues found
- py3.10:  No issues found

linux-64:
- py3.7:  No issues found
- py3.8:  No issues found
- py3.9:  No issues found
- py3.10:  No issues found

linux-ppc64le:
- py3.7:  No issues found
- py3.8:  No issues found
- py3.9:  No issues found
- py3.10:  No issues found

linux-s390x:
- py3.7:  No issues found
- py3.8:  No issues found
- py3.9:  No issues found
- py3.10:  No issues found

osx-64:
- py3.7:  No issues found
- py3.8:  No issues found
- py3.9:  No issues found
- py3.10:  No issues found

osx-arm64:
- py3.8:  No issues found
- py3.9:  No issues found
- py3.10:  No issues found

win-64:
- py3.7:  No issues found
- py3.8:  No issues found
- py3.9:  No issues found
- py3.10:  No issues found

</details>

**Package Build Score: 18**


</details>



**Links:**
* [Anaconda Recipes feedstock](https://github.com/AnacondaRecipes/sphinxcontrib-applehelp-feedstock)
* [Update branch](https://github.com/AnacondaRecipes/sphinxcontrib-applehelp-feedstock/tree/1.0.4)
* [conda-forge recipe](https://github.com/conda-forge/{feedstock_name}-feedstock)
* [PyPI](https://pypi.org/project/sphinxcontrib-applehelp)
* [Diff between upstream and feature branch](https://github.com/conda-forge/sphinxcontrib-applehelp-feedstock/compare/main...AnacondaRecipes:1.0.4)
* [Diff between origin and feature branch](https://github.com/AnacondaRecipes/sphinxcontrib-applehelp-feedstock/compare/master...AnacondaRecipes:1.0.4)
* [The last merged PRs](https://github.com/AnacondaRecipes/sphinxcontrib-applehelp-feedstock/pulls?q=is%3Apr+is%3Amerged+sort%3Aupdated-desc+)

**Updating the recipe:**
If the recipe needs additional modification the update branch can be modified. Note that the PR diffs are not updated with these changes.
```
git clone -b 1.0.4 git@github.com:AnacondaRecipes/sphinxcontrib-applehelp-feedstock.git
```
