### PR TITLE
sphinxcontrib-applehelp 2.0.0 

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,3 +1,0 @@
-build_env_vars:
-  ANACONDA_ROCKET_ENABLE_PY313: yes
-

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,3 @@
+build_env_vars:
+  ANACONDA_ROCKET_ENABLE_PY313: yes
+

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,24 +1,27 @@
-{% set version = "1.0.2" %}
+{% set name = "sphinxcontrib-applehelp" %}
+{% set version = "2.0.0" %}
 
 package:
-  name: sphinxcontrib-applehelp
+  name: {{ name }}
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/s/sphinxcontrib-applehelp/sphinxcontrib-applehelp-{{ version }}.tar.gz
-  sha256: a072735ec80e7675e3f432fcae8610ecf509c5f1869d17e2eecff44389cdbc58
+  url: https://pypi.org/packages/source/s/sphinxcontrib-applehelp/sphinxcontrib_applehelp-{{ version }}.tar.gz
+  sha256: 2f29ef331735ce958efa4734873f084941970894c6090408b079c61b2e1c06d1
 
 build:
   number: 0
-  noarch: python
   script: {{ PYTHON }} -m pip install . --no-deps -vv
+  skip: true  # [py<39]
 
 requirements:
   host:
-    - python >=3.5
+    - python
     - pip
+    - flit-core >=3.7
   run:
-    - python >=3.5
+    - python
+    - sphinx >=5
 
 test:
   requires:
@@ -35,8 +38,11 @@ about:
   home: http://sphinx-doc.org/
   license: BSD-2-Clause
   license_family: BSD
-  license_file: LICENSE
+  license_file: LICENCE.rst
   summary: sphinxcontrib-applehelp is a sphinx extension which outputs Apple help books
+  doc_url: https://www.sphinx-doc.org/en/master/
+  dev_url: https://github.com/sphinx-doc/sphinxcontrib-applehelp
+
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
 
 build:
   number: 0
-  script: {{ PYTHON }} -m pip install . --no-deps -vv
+  script: {{ PYTHON }} -m pip install . --no-deps -vv --no-build-isolation
   noarch: python
 
 requirements:
@@ -35,7 +35,7 @@ test:
     - sphinxcontrib.applehelp
 
 about:
-  home: http://sphinx-doc.org/
+  home: https://sphinx-doc.org/
   license: BSD-2-Clause
   license_family: BSD
   license_file: LICENCE.rst

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,15 +12,15 @@ source:
 build:
   number: 0
   script: {{ PYTHON }} -m pip install . --no-deps -vv
-  skip: true  # [py<39]
+  noarch: python
 
 requirements:
   host:
-    - python
+    - python >=3.9
     - pip
     - flit-core >=3.7
   run:
-    - python
+    - python >=3.9
     - sphinx >=5
 
 test:


### PR DESCRIPTION
sphinxcontrib-applehelp 2.0.0 

**Destination channel:** Defaults

### Links

- [PKG-7689]
- dev_url:        https://github.com/sphinx-doc/sphinxcontrib-applehelp/tree/2.0.0
- conda_forge:    https://github.com/conda-forge/sphinxcontrib-applehelp-feedstock
- pypi:           https://pypi.org/project/sphinxcontrib-applehelp/2.0.0
- pypi inspector: https://inspector.pypi.io/project/sphinxcontrib-applehelp/2.0.0
- Required for:
    - https://github.com/AnacondaRecipes/sphinx-feedstock/pull/18

### Explanation of changes:

- new version number
- keeping noarch due to test circular dependencies with sphinx


[PKG-7689]: https://anaconda.atlassian.net/browse/PKG-7689?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ