### PR TITLE
sphinxcontrib-applehelp 2.0.0 rebuild

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -26,7 +26,7 @@ test:
   requires:
     - pip
     # This is a circular dependency b/c sphinx depends on this package now :-/
-    - sphinx >=2
+    - sphinx >=5
   commands:
     - pip check
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,18 +10,17 @@ source:
   sha256: 2f29ef331735ce958efa4734873f084941970894c6090408b079c61b2e1c06d1
 
 build:
-  number: 0
+  number: 1
   script: {{ PYTHON }} -m pip install . --no-deps -vv --no-build-isolation
   noarch: python
 
 requirements:
   host:
-    - python >=3.9
+    - python 3.9
     - pip
     - flit-core >=3.7
   run:
     - python >=3.9
-    - sphinx >=5
 
 test:
   requires:


### PR DESCRIPTION
sphinxcontrib-applehelp 2.0.0 rebuild

**Destination channel:** Defaults

### Links

- [PKG-7689]
- dev_url:        https://github.com/sphinx-doc/sphinxcontrib-applehelp/tree/2.0.0
- conda_forge:    https://github.com/conda-forge/sphinxcontrib-applehelp-feedstock
- pypi:           https://pypi.org/project/sphinxcontrib-applehelp/2.0.0
- pypi inspector: https://inspector.pypi.io/project/sphinxcontrib-applehelp/2.0.0
- Required for:
    - https://github.com/AnacondaRecipes/sphinx-feedstock/pull/18

### Explanation of changes:

- rebuild to fix python pinnings


[PKG-7689]: https://anaconda.atlassian.net/browse/PKG-7689?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ